### PR TITLE
feat: add checkup after two hours after !play

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -177,18 +177,16 @@ impl EventHandler for Handler {
 }
 
 fn schedule_checkup(ctx: Context, channel_id: serenity::model::id::ChannelId, on: Vec<User>) {
+    let msg = format!(
+        "Hey, hey! {}, it has been 2 hours since you started playing! \
+        Remember to hydrate, take some rest, or possibly call it a day.",
+        on.iter()
+            .map(|p| p.mention().to_string())
+            .collect::<Vec<_>>()
+            .join(", ")
+    );
     tokio::task::spawn(async move {
         tokio::time::sleep(CHECKUP_WAITTIME).await;
-
-        let mut msg = String::from("Hey, hey! ");
-        msg.push_str(
-            &on.iter()
-                .map(|p| p.mention().to_string())
-                .collect::<Vec<_>>()
-                .join(", ")
-                .to_owned(),
-        );
-        msg.push_str(" it has been 2 hours since you started playing! Remember to hydrate, take some rest, or possibly call it a day.");
         if let Err(e) = channel_id.say(&ctx.http, msg).await {
             eprintln!("Error sending message: {:?}", e);
         };

--- a/src/main.rs
+++ b/src/main.rs
@@ -141,7 +141,7 @@ impl EventHandler for Handler {
                 Some(gather.status())
             }
             "!play" => {
-                schedule_checkup(ctx.clone(), msg.channel_id, gather.players.clone());
+                schedule_checkup(&ctx, &msg.channel_id, &gather.players);
                 Some(gather.play())
             }
             "!status" => Some(gather.status()),
@@ -176,7 +176,9 @@ impl EventHandler for Handler {
     }
 }
 
-fn schedule_checkup(ctx: Context, channel_id: serenity::model::id::ChannelId, on: Vec<User>) {
+fn schedule_checkup(ctx: &Context, channel_id: &serenity::model::id::ChannelId, on: &Vec<User>) {
+    let ctx = ctx.to_owned();
+    let channel_id = channel_id.to_owned();
     let msg = format!(
         "Hey, hey! {}, it has been 2 hours since you started playing! \
         Remember to hydrate, take some rest, or possibly call it a day.",

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ use plugins::*;
 
 static ENVIRONMENT_VARIABLE_NAME: &str = "KOROVA_TOKEN";
 static MIN_PLAYERS: usize = 2;
+static CHECKUP_WAITTIME: std::time::Duration = std::time::Duration::from_secs(60 * 60 * 2);
 
 struct Handler;
 
@@ -177,7 +178,7 @@ impl EventHandler for Handler {
 
 fn schedule_checkup(ctx: Context, channel_id: serenity::model::id::ChannelId, on: Vec<User>) {
     tokio::task::spawn(async move {
-        tokio::time::sleep(std::time::Duration::from_secs(60 * 60 * 2)).await;
+        tokio::time::sleep(CHECKUP_WAITTIME).await;
 
         let mut msg = String::from("Hey, hey! ");
         msg.push_str(


### PR DESCRIPTION
Possible improvements:
 - Checking whether players are still in a voice chat
 - Customizing duration, e.g. by using `!play 2h`